### PR TITLE
Minor fix in prompt

### DIFF
--- a/src/proofreader.rs
+++ b/src/proofreader.rs
@@ -7,8 +7,8 @@ use serde_json::json;
 const SYSTEM_PROMPT: &str = r" \
 You are an expert proofreader. Analyze the provided text and identify any corrections needed to fix
 grammar or spelling. For each mistake, identify the startIndex, endIndex, the mistake type, report
-the correction and an explanation. The startIndex must the the first character of the error in the
-original text and endIndex the last. IT'S VERY IMPORTANTO TO GET startIndex AND endIndex CORRECTLY,
+the correction and an explanation. The startIndex must be the first character of the mistake in the
+original text, and endIndex the last. IT'S VERY IMPORTANTO TO GET startIndex AND endIndex CORRECTLY,
 OTHERWISE KITTENS WILL DIE. Finally, provide the entire corrected string.";
 const MODEL: &str = "gemini-2.0-pro-exp-02-05";
 


### PR DESCRIPTION
I doubt it will improve the situation much, but maybe it does, who knows.

If you want, you can also add an example, so the model has something to base its output upon:

**Input:**

```
This are a radnom text with a few classic common, and typicla typso and grammar issus. the Proofreader API hopefuly finds them all. Knocking at wood and crossed.
```

**Output:**

```json
{
  "corrected": "This is a random text with a few classic, common, and typical typos and grammar issues. The Proofreader API hopefully finds them all.",
  "corrections": [
    {
      "startIndex": 5,
      "endIndex": 8,
      "correction": "is",
      "type": "grammar",
      "explanation": "The singular 'This' requires 'is' instead of 'are'."
    },
    {
      "startIndex": 11,
      "endIndex": 17,
      "correction": "random",
      "type": "spelling",
      "explanation": "'radnom' is a misspelling of 'random'."
    },
    {
      "startIndex": 40,
      "endIndex": 43,
      "correction": "c, c",
      "type": "punctuation",
      "explanation": "A comma is needed between 'classic' and 'common' for clarity."
    },
    {
      "startIndex": 54,
      "endIndex": 61,
      "correction": "typical",
      "type": "spelling",
      "explanation": "'typicla' is a misspelling of 'typical'."
    },
    {
      "startIndex": 62,
      "endIndex": 67,
      "correction": "typos",
      "type": "spelling",
      "explanation": "'typso' is a misspelling of 'typos'."
    },
    {
      "startIndex": 80,
      "endIndex": 85,
      "correction": "issues",
      "type": "spelling",
      "explanation": "'issus' is a misspelling of 'issues'."
    },
    {
      "startIndex": 87,
      "endIndex": 90,
      "correction": "The",
      "type": "capitalization",
      "explanation": "'the' should be capitalized after a period."
    },
    {
      "startIndex": 107,
      "endIndex": 115,
      "correction": "hopefully",
      "type": "spelling",
      "explanation": "'hopefuly' is a misspelling of 'hopefully'."
    },
    {
      "startIndex": 141,
      "endIndex": 143,
      "correction": "on",
      "type": "preposition",
      "explanation": "The preposition 'at' should be 'on'."
    },

    {
      "startIndex": 151,
      "endIndex": 154,
      "correction": "d fingers c",
      "type": "missing-words",
      "explanation": "There was the word 'fingers' missing."
    }
  ]
}
```